### PR TITLE
Concat received data parts in client

### DIFF
--- a/chromix-too.coffee
+++ b/chromix-too.coffee
@@ -23,10 +23,14 @@ module.exports = (sock = config.sock) ->
       client = require("net").connect sock, ->
         client.write JSON.stringify request
 
+      dataParts = []
       client.on "data", (data) ->
-        response = JSON.parse data.toString "utf8"
-        if response.error
-          console.error "error: #{response.error}"
-          process.exit 1
-        callback response.response... for callback in callbacks
-        client.destroy()
+        dataParts.push(data);
+        if data.length != 65536
+          concatData = Buffer.concat(dataParts)
+          response = JSON.parse concatData.toString "utf8"
+          if response.error
+            console.error "error: #{response.error}"
+            process.exit 1
+          callback response.response... for callback in callbacks
+          client.destroy()


### PR DESCRIPTION
Fixes #6 

The nodejs socket server sends data over in 65536B chunks [1], this commit concats them. Note that the `!= 65536` is quite hacky and shoudn't be merged. It should instead rely on the `end` event of the client [1], which I couldn't get to work unfortunately.

[1] https://nodejs.org/api/net.html
[2] http://stackoverflow.com/questions/36397950/how-to-send-file-over-tcp-in-one-time-in-nodejs