### PR TITLE
Clean up build pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,21 @@
-
-src = utils.coffee extension/utils.coffee chromix-too.coffee server.coffee client.coffee
-js  = $(src:.coffee=.js)
+src := $(wildcard *.coffee */*.coffee)
+js  := $(src:.coffee=.js)
 
 build: $(js)
-	@true
 
 auto:
-	watch -n 1 make build
+	npx watch -n 1 "make build"
 
-install:
-	$(MAKE) build
+%.js: %.coffee
+	npx coffee -c --bare --no-header $<
+
+install: build
 	sudo npm install -g .
 
 extension:
-	$(MAKE) -C extension build
+	$(MAKE) -C extension package
 
-%.js: %.coffee
-	coffee -c --bare --no-header $<
-
-publish:
-	$(MAKE) build
+publish: build
 	npm publish
 
 .PHONY: build auto install extension publish

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -1,25 +1,19 @@
-
-src = $(wildcard *.coffee)
-js  = $(src:.coffee=.js)
+src := $(wildcard *.coffee)
+js  := $(src:.coffee=.js)
 
 build: $(js)
-	@true
 
 auto:
-	coffee -cw .
+	npx watch -n 1 "make build"
 
 %.js: %.coffee
-	coffee -c $<
+	npx coffee -c --bare --no-header $<
+
+pkg := chromix-too.zip
+
+$(pkg): $(js) manifest.json
+	zip $(pkg) manifest.json $(js)
+
+package: $(pkg)
 
 .PHONY: build auto package
-
-pkg = chromix-too.zip
-
-package:
-	! test -f $(pkg) || rm -vf $(pkg)
-	$(MAKE) build
-	zip chromix-too.zip \
-	   manifest.json \
-	   utils.js \
-	   background.js \
-	   foreground.js

--- a/package.json
+++ b/package.json
@@ -33,5 +33,9 @@
    "bin": {
       "chromix-too-server": "server.js",
       "chromix-too": "client.js"
+   },
+   "devDependencies": {
+      "coffeescript": "^2.2.3",
+      "watch": "^1.0.2"
    }
 }


### PR DESCRIPTION
In this Pull Request I tried to make the build pipeline a bit cleaner:

- Use wildcards in both Makefiles
- Task Ordering
- Dependencies
- Put `watch` and `coffeescript` in `devDependencies` and use npx to run them