### PR TITLE
Migrate extension to Manifest V3

### DIFF
--- a/extension/background.coffee
+++ b/extension/background.coffee
@@ -1,3 +1,5 @@
+importScripts 'utils.js'
+
 # TODO:
 #   - Add a config page to set port (and possibly host) of the server.
 
@@ -13,7 +15,7 @@ handleRequest = (sock) -> ({data}) ->
     sock.send JSON.stringify extend request, response: ["ok"], error: false
 
   else
-    obj = window
+    obj = self
     for property in path.split "."
       try
         obj = obj[property]
@@ -32,7 +34,12 @@ reTryConnect = ->
   console.log "disconnected, retry connection in #{config.timeout}ms..."
   setTimeout tryConnect, config.timeout
 
+sock = null
+
 tryConnect = ->
+  if(sock && (sock.readyState == WebSocket.OPEN || sock.readyState == WebSocket.CONNECTING))
+    return
+
   reTryFunction = makeIdempotent reTryConnect
   try
     url = "ws://#{config.host}:#{config.port}/"
@@ -43,5 +50,9 @@ tryConnect = ->
   sock.onmessage = handleRequest sock
   console.log "connected: #{url}"
 
-tryConnect()
+chrome.runtime.onInstalled.addListener tryConnect
+chrome.runtime.onStartup.addListener tryConnect
 
+chrome.alarms.create 'keepAlive', periodInMinutes: 0.4
+chrome.alarms.onAlarm.addListener (alarm) ->
+  tryConnect() if alarm.name == 'keepAlive'

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Chromix-Too",
-  "version": "0.0.2",
-  "manifest_version": 2,
+  "version": "0.0.3",
+  "manifest_version": 3,
   "description": "Command-line or scripted access to chrome's extension API.",
 
   "permissions": [
@@ -13,13 +13,13 @@
     "sessions",
     "notifications",
     "webNavigation",
+    "alarms"
+  ],
+  "host_permissions": [
     "<all_urls>"
   ],
 
-  "background": { "scripts":
-     [
-        "utils.js",
-        "background.js"
-     ]
+  "background": {
+    "service_worker": "background.js"
   }
 }

--- a/extension/utils.coffee
+++ b/extension/utils.coffee
@@ -1,4 +1,4 @@
-root = exports ? window
+root = exports ? self
 
 extend = root.extend = (hash1, hash2) ->
   hash1[key] = hash2[key] for own key of hash2


### PR DESCRIPTION
This pull request migrates the `chromix-too` extension to Manifest V3.

The `chromix-too` extension was removed from the Chrome Web Store, and the bundled extension included with the NPM package uses Manifest V2 which is no longer supported, even when changing options within `chrome://flags`.

- This also implicitly resolves #26 by providing a means of compiling the extension locally.

The following changes have been made:

- Bump manifest version and extension version in `manifest.json`.
  - https://developer.chrome.com/docs/extensions/develop/migrate/manifest#change-version
- Replace `background.scripts` array with `background.service_worker` in `manifest.json`.
  - https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#update-bg-field
  - Add `importScripts 'utils.js'` to top of `background.coffee`.
  - Replace `window` with `self` in `background.coffee` and `utils.coffee`.
- Move `<all_urls>` from `permissions` to `host_permissions` in `manifest.json`.
  - https://developer.chrome.com/docs/extensions/develop/migrate/manifest#update-host-permissions
- Use alarms to keep service worker alive after 30 seconds of inactivity.
  - https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle#idle-shutdown

These changes have been tested locally on Google Chrome version 148.0.7778.217 and have produced no extension runtime errors.